### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/Merge.ts
+++ b/src/Merge.ts
@@ -47,12 +47,17 @@ const  handleDefaultBehavior = (originalObject: any, newObject: any, behavior?: 
     if (originalTypeName === "Object" && newTypeName === "Object") { // built-in behavior
         // tslint:disable:forin
         for (const p in newObject) {
+            if (isPrototypePolluted(p)) continue
             originalObject[p] = processBehavior(originalObject[p], newObject[p], behavior);
         }
         // tslint:enable:forin
         return originalObject;
     }
 };
+
+const isPrototypePolluted = (key: any) => {
+    return ['__proto__', 'constructor', 'prototype'].includes(key)
+}
 
 /**
  * Recursively merge two objects together.
@@ -72,7 +77,7 @@ export const Merge = (originalObject: any, newObject: any, behavior?: IMergeBeha
             return definedBehaviorResults;
         }
     }
-
+    
     return handleDefaultBehavior(originalObject, newObject, behavior);
 };
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`ts-nodash` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-ts-nodash

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var merge = require("ts-nodash").Merge
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
merge(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i ts-nodash # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![ts-nodash-fix](https://user-images.githubusercontent.com/43996156/102844005-79f2b400-4430-11eb-9f19-1d87ccba1e31.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
